### PR TITLE
Add author notification section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+**Notify authors**
+* @lastlink
+
 Fixes # .
 
 Changes proposed in this pull request:


### PR DESCRIPTION
Added a section to notify authors in the PR template.

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 